### PR TITLE
Throw error with reject in service.request

### DIFF
--- a/src/controllers/serviceController.ts
+++ b/src/controllers/serviceController.ts
@@ -81,16 +81,20 @@ export default class ServiceController {
     this.checkRunning(serviceName);
     const result = await new Promise(async (resolve, reject) => {
       const requestKey = Date.now();
-      const requesterAddress = this.ain.getAddress();
-      const responsePath = Path.app(serviceName).response(requesterAddress, requestKey.toString());
-      await this.handler.subscribe(responsePath, resolve);
-      const requestPath = Path.app(serviceName).request(requesterAddress, requestKey);
-      const requestOp = buildSetOperation("SET_VALUE", requestPath, requestData);
-      const txBody = buildTxBody(requestOp);
-      await this.ain.sendTransaction(txBody);
-      return requestKey;
+      try {
+        const requesterAddress = this.ain.getAddress();
+        const responsePath = Path.app(serviceName).response(requesterAddress, requestKey.toString());
+        await this.handler.subscribe(responsePath, resolve);
+        const requestPath = Path.app(serviceName).request(requesterAddress, requestKey);
+        const requestOp = buildSetOperation("SET_VALUE", requestPath, requestData);
+        const txBody = buildTxBody(requestOp);
+        await this.ain.sendTransaction(txBody);
+      } catch (e: any) {
+        if (e instanceof Error)
+          return reject(new Error(e.message));
+      }
     });
-    return result as string;
+    return result;
   }
 
   async run(serviceName: string): Promise<void> {


### PR DESCRIPTION
promise 안에서 throw Error 할 경우 외부에서 catch 하지 못하는 이슈가 있어 reject 를 통해 에러를 발생시키도록 변경하였습니다.