### PR TITLE
blockchainTriggerFilter & deploy url check

### DIFF
--- a/src/ainize.ts
+++ b/src/ainize.ts
@@ -83,6 +83,7 @@ export default class Ainize {
       if (!serviceUrl) {
         serviceUrl = `https://${serviceName}.ainetwork.xyz`;
       }
+      serviceUrl = serviceUrl.replace(/\/$/, '');
       const servicePath = Path.app(serviceName).status();
       await this.handler.subscribe(servicePath, resolve);
       await this.appController.createApp({ appName: serviceName, serviceUrl, billingConfig });

--- a/src/controllers/serviceController.ts
+++ b/src/controllers/serviceController.ts
@@ -48,7 +48,7 @@ export default class ServiceController {
   }
 
   async chargeCredit(serviceName: string, amount: number): Promise<string> {
-    this.checkRunning(serviceName);
+    await this.checkRunning(serviceName);
     const transferKey = Date.now();
     const userAddress = this.ain.getAddress(); 
     const depositAddress = await this.getDepositAddress(serviceName);
@@ -78,7 +78,7 @@ export default class ServiceController {
   }
 
   async request(serviceName: string, requestData: any) : Promise<any> {
-    this.checkRunning(serviceName);
+    await this.checkRunning(serviceName);
     const result = await new Promise(async (resolve, reject) => {
       const requestKey = Date.now();
       const requesterAddress = this.ain.getAddress();

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -4,6 +4,7 @@ import { getChangeBalanceOp, getResponseOp, getWriteHistoryOp } from "./utils/op
 import { HISTORY_TYPE, RESPONSE_STATUS, deposit, request, response } from "./types/type";
 import { buildTxBody } from "./utils/builder";
 import AinModule from "./ain";
+import { extractDataFromDepositRequest, extractDataFromServiceRequest } from "./utils/extractor";
 
 export default class Internal {
   private ain = AinModule.getInstance();
@@ -35,28 +36,10 @@ export default class Internal {
   }
   
   getDataFromServiceRequest(req: Request) {
-    if(!req.body.valuePath[1] || !req.body.valuePath[3] || !req.body.valuePath[4] || !req.body.value) {
-      throw new Error("Not from service request");
-    }
-    const requestData: request = {
-      appName: req.body.valuePath[1],
-      requesterAddress: req.body.auth.addr,
-      requestKey: req.body.valuePath[4],
-      requestData: req.body.value,
-    }
-    return requestData;
+    return extractDataFromServiceRequest(req);
   }
 
   private getDataFromDepositRequest(req: Request) {
-    if(!req.body.valuePath[1] || !req.body.valuePath[4] || !req.body.value) {
-      throw new Error("Not from deposit request");
-    }
-    const depositData: deposit = {
-      transferKey: req.body.valuePath[4],
-      transferValue: req.body.value,
-      appName: req.body.valuePath[1],
-      requesterAddress: req.body.auth.addr,
-    }
-    return depositData;
+    return extractDataFromDepositRequest(req);
   }
 }

--- a/src/middlewares/middleware.ts
+++ b/src/middlewares/middleware.ts
@@ -29,7 +29,7 @@ export default class Middleware {
       return;
     }
     this.cache.set(txHash, "in_progress", 500);
-    _.isEqual(result, triggerValue) ? res.send("not from blockChain") : next();
+    _.isEqual(result, triggerValue) ? next(): res.send("not from blockChain");
   }
   /**
    *  DEPRECATED

--- a/src/middlewares/middleware.ts
+++ b/src/middlewares/middleware.ts
@@ -1,51 +1,39 @@
 import { Request, Response, NextFunction } from "express";
 import NodeCache = require("node-cache");
+import { extractTriggerDataFromRequest } from "../utils/extractor";
+import AinModule from "../ain";
+import _ from "lodash";
 
 export default class Middleware {
   cache: NodeCache;
-  constructor(cache: NodeCache,) {
+  private ain = AinModule.getInstance();
+  constructor(cache: NodeCache) {
     this.cache = cache;
   }
 
   /**
    * Middleware for AI Network trigger call. It will filter duplicated request triggered by same transaction.
-   * It will pass request which is not from AI Network trigger.
+   * It will reject requests which is not from AI Network trigger.
    * @param {Request} request - Request data 
    * @param {Res} response - Response data
    * @param {NextFunction} next - Next function
    * @returns Null if if request is duplicated.
    */
-  triggerDuplicateFilter = (req: Request, res: Response, next: NextFunction) => {
-    if (req.body.transaction.hash === undefined){
-      next();
-    }
-    const txHash = req.body.transaction.hash;
+  blockchainTriggerFilter = async (req: Request, res: Response, next: NextFunction) => {
+    //check if request is from blockchain trigger
+    const { triggerPath, triggerValue, txHash } = extractTriggerDataFromRequest(req);
+    const result = await this.ain.getValue(triggerPath);
+    // if request is first reque st, set cache 
     if (this.cache.get(txHash) && this.cache.get(txHash) !== "error") {
       res.send("duplicated");
       return;
     }
-      // if request is first request, set cache 
     this.cache.set(txHash, "in_progress", 500);
-    next();
+    _.isEqual(result, triggerValue) ? res.send("not from blockChain") : next();
   }
-    /**
-   * Middleware for AI Network trigger call. It will filter duplicated request triggered by same transaction.
-   * It will pass request which is not from AI Network trigger.
-   * You can set filter inside specific api.
-   * @param {Request} request - Request data 
-   * @param {Res} response - Response data
-   * @returns Null if if request is duplicated.
+  /**
+   *  DEPRECATED
+   *  use blockchainTriggerFilter instead
    */
-  triggerFilter = (req: Request, res: Response) => {
-    if (req.body.fid || req.body.transaction){
-      res.send("not from trigger");
-      return;
-    }
-    const txHash = req.body.transaction.hash;
-    if (this.cache.get(txHash) && this.cache.get(txHash) !== "error") {
-      res.send("duplicated");
-      return;
-    }
-    this.cache.set(txHash, "in_progress", 500);
-  }
+  triggerDuplicateFilter = this.blockchainTriggerFilter;
 }

--- a/src/utils/extractor.ts
+++ b/src/utils/extractor.ts
@@ -1,0 +1,45 @@
+import { Request } from "express";
+import { deposit, request } from "../types/type";
+
+export const extractDataFromServiceRequest = (req:Request) => {
+  if(!req.body.valuePath[1] || !req.body.valuePath[3] || !req.body.valuePath[4] || !req.body.value) {
+    throw new Error("Not from service request");
+  }
+  const requestData: request = {
+    appName: req.body.valuePath[1],
+    requesterAddress: req.body.auth.addr,
+    requestKey: req.body.valuePath[4],
+    requestData: req.body.value,
+  }
+  return requestData;
+}
+
+export const extractTriggerDataFromRequest = (req:Request) => {
+  if(req?.body?.valuePath === undefined) {
+    throw new Error("Not from trigger request");
+  }
+  let path = '';
+  req.body.valuePath.forEach((value:string) => {
+    path += value + '/';
+  }
+  );
+  const triggerData = {
+    triggerPath: path,
+    triggerValue: req.body.value,
+    txHash: req.body.txhash,
+  }
+  return triggerData
+}
+
+export const extractDataFromDepositRequest = (req:Request) => {
+  if(!req.body.valuePath[1] || !req.body.valuePath[4] || !req.body.value) {
+    throw new Error("Not from deposit request");
+  }
+  const depositData: deposit = {
+    transferKey: req.body.valuePath[4],
+    transferValue: req.body.value,
+    appName: req.body.valuePath[1],
+    requesterAddress: req.body.auth.addr,
+  }
+  return depositData;
+}


### PR DESCRIPTION
### blockchainTriggerFilter
- 데이터가 실제로 작성되었는지를 통해 blockchain trigger 검증 로직을 추가했습니다.

### deploy url check
- deploy할 때 입력한 URL의 뒷부분에 '/'가 있으면 제거하는 코드를 추가했습니다.

### getDataFromServiceRequest, getDataFromDepositRequest util로 이동.
- getData들의 구현체를 util의 extractor.ts로 이동시켰습니다. (middleware에서도 사용하기 위해서)

### await this.checkRunning
- checkRunning이 비동기로 작동해 코드가 실행된 후 에러가 발생하는 문제가 발생해 await을 추가했습니다.