### PR TITLE
[Hotfix] Checking address on Handler fallback 

### DIFF
--- a/src/handlers/handler.ts
+++ b/src/handlers/handler.ts
@@ -28,13 +28,18 @@ export default class Handler {
   async disconnect() {
     this.checkEventManager();
     await this.ain.getEventManager().disconnect();
-    console.log('disconnected');
+    console.log('Disconnected');
   }
 
   private async disconnectedCb() {
-    if(await AinModule.getInstance().getAddress()) {
-      console.log('disconnected. reconnecting...');
-      await this.connect();
+    try {
+      const address = await AinModule.getInstance().getAddress();
+      if (address) {
+        console.log('Disconnected. Reconnecting...');
+        await this.connect();
+      }
+    } catch (_) {
+      return;
     }
   }
 


### PR DESCRIPTION
Request event handler 의 fallback 함수 disconnectedCb 에서 address 유무 판단 시 address가 존재하지 않으면 에러가 발생하는 것을 방지하기 위한 코드를 추가하였습니다.