### PR TITLE
Deprecate connection retry callback and support custom client id parameter

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "typescript": "^4.6.3"
   },
   "dependencies": {
-    "@ainblockchain/ain-js": "^1.12.0",
+    "@ainblockchain/ain-js": "^1.13.0",
     "axios": "^0.26.1",
     "express": "^4.18.2",
     "fast-json-stable-stringify": "^2.1.0",

--- a/src/ainize.ts
+++ b/src/ainize.ts
@@ -36,21 +36,27 @@ export default class Ainize {
 
   /**
    * Login to ainize using AI Network account private key.
-   * @param {string} privateKey 
+   * @param {string} privateKey The private key to initialize the AinModule with.
+   * @param {ConnectionCallback} ConnectionCallback The connection callback function.
+   * @param {DisconnectionCallback} disconnectionCallback The disconnection callback function.
+   * @param {string} customClientId The custom client id to set.
    */
-  async login(privateKey: string, connectionCb?: ConnectionCallback, disconnectionCb?: DisconnectionCallback) {
+  async login(privateKey: string, connectionCb?: ConnectionCallback, disconnectionCb?: DisconnectionCallback, customClientId?: string) {
     this.ain.setDefaultAccount(privateKey);
-    await this.handler.connect(connectionCb, disconnectionCb);
+    await this.handler.connect(connectionCb, disconnectionCb, customClientId);
     console.log('login success! address:', await this.ain.getAddress());
   }
 
   /**
    * Login to ainize using AIN Wallet Signer.
+   * @param {ConnectionCallback} ConnectionCallback The connection callback function.
+   * @param {DisconnectionCallback} disconnectionCallback The disconnection callback function.
+   * @param {string} customClientId The custom client id to set.
    */
-  async loginWithSigner(connectionCb?: ConnectionCallback, disconnectionCb?: DisconnectionCallback) {
+  async loginWithSigner(connectionCb?: ConnectionCallback, disconnectionCb?: DisconnectionCallback, customClientId?: string) {
     const signer = new AinWalletSigner;
     this.ain.setSigner(signer);
-    await this.handler.connect(connectionCb, disconnectionCb);
+    await this.handler.connect(connectionCb, disconnectionCb, customClientId);
     console.log('login success! address: ', await this.ain.getAddress());
   }
 

--- a/src/handlers/handler.ts
+++ b/src/handlers/handler.ts
@@ -26,7 +26,7 @@ export default class Handler {
 
   async connect(connectionCb?: ConnectionCallback, disconnectionCb?: DisconnectionCallback, customClientId?: string) {
     this.checkEventManager();
-    await this.ain.getEventManager().connect(connectionCb, this.connectionRetryCb.bind(this, connectionCb, disconnectionCb, customClientId));
+    await this.ain.getEventManager().connect(connectionCb, disconnectionCb, customClientId);
     console.log('connected');
   };
   
@@ -34,21 +34,6 @@ export default class Handler {
     this.checkEventManager();
     await this.ain.getEventManager().disconnect();
     console.log('Disconnected');
-  }
-
-  private async connectionRetryCb(connectionCb?: ConnectionCallback, disconnectionCb?: DisconnectionCallback, customClientId?: string, webSocket?: any) {
-    try {
-      if (disconnectionCb) {
-        disconnectionCb(webSocket);
-      }
-      const address = await AinModule.getInstance().getAddress();
-      if (address) {
-        console.log('Disconnected. Reconnecting...');
-        await this.connect(connectionCb, disconnectionCb, customClientId);
-      }
-    } catch (_) {
-      return;
-    }
   }
 
   async subscribe(subscribePath: string, resolve: any) {

--- a/src/handlers/handler.ts
+++ b/src/handlers/handler.ts
@@ -24,9 +24,9 @@ export default class Handler {
     return this.ain.getEventManager().isConnected();
   }
 
-  async connect(connectionCb?: ConnectionCallback, disconnectionCb?: DisconnectionCallback) {
+  async connect(connectionCb?: ConnectionCallback, disconnectionCb?: DisconnectionCallback, customClientId?: string) {
     this.checkEventManager();
-    await this.ain.getEventManager().connect(connectionCb, this.connectionRetryCb.bind(this, connectionCb, disconnectionCb));
+    await this.ain.getEventManager().connect(connectionCb, this.connectionRetryCb.bind(this, connectionCb, disconnectionCb, customClientId));
     console.log('connected');
   };
   
@@ -36,7 +36,7 @@ export default class Handler {
     console.log('Disconnected');
   }
 
-  private async connectionRetryCb(connectionCb?: ConnectionCallback, disconnectionCb?: DisconnectionCallback, webSocket?: any) {
+  private async connectionRetryCb(connectionCb?: ConnectionCallback, disconnectionCb?: DisconnectionCallback, customClientId?: string, webSocket?: any) {
     try {
       if (disconnectionCb) {
         disconnectionCb(webSocket);
@@ -44,7 +44,7 @@ export default class Handler {
       const address = await AinModule.getInstance().getAddress();
       if (address) {
         console.log('Disconnected. Reconnecting...');
-        await this.connect(connectionCb, disconnectionCb);
+        await this.connect(connectionCb, disconnectionCb, customClientId);
       }
     } catch (_) {
       return;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@ainblockchain/ain-js@^1.12.0":
-  version "1.12.0"
-  resolved "https://registry.yarnpkg.com/@ainblockchain/ain-js/-/ain-js-1.12.0.tgz#6bd2c051ae200b6a8eee28d175f14fa677f56e04"
-  integrity sha512-wsipsiVzgtAkNhBR04t/UlQ7nXnIt1MRU11kctYzCbFsz8YrVhrX6WM2kXxWEsm37KnmtsZkt7f6WgfO/JdM4Q==
+"@ainblockchain/ain-js@^1.13.0":
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/@ainblockchain/ain-js/-/ain-js-1.13.0.tgz#547a036385ac8ea2fb9a643cbf8151bf4c4b65ed"
+  integrity sha512-XFxbxamfoUbgh6iOUjIQZPduotEI32lsRZxYCjD5SGlQ/kXzdrZ9rz0EJCFoE0O/Nu6bawC7h96Jvc8M/xon0w==
   dependencies:
     "@ainblockchain/ain-util" "^1.2.1"
     "@types/node" "^12.7.3"


### PR DESCRIPTION
Change summary:
- Support custom client id parameter in making connections with connect()
- Deprecate connection retry callback
- Upgrade ain-js package to v1.13.0

Related issues:
- https://github.com/ainblockchain/ain-blockchain/issues/1290

Related PRs:
- https://github.com/ainblockchain/ain-js/pull/205
- https://github.com/ainblockchain/ain-js/pull/206